### PR TITLE
[CTYP-248] Move lexical environment to an accessible location

### DIFF
--- a/module-check/src/main/clojure/clojure/core/typed/check.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check.clj
@@ -1849,7 +1849,7 @@
                               (free-ops/with-free-mappings 
                                 (zipmap (map (comp r/F-original-name r/make-F) nms) 
                                         (map (fn [nm bnd] {:F (r/make-F nm) :bnds bnd}) nms bbnds))
-                                ;(prn "lexical env when checking method" method-nme lex/*lexical-env*)
+                                ;(prn "lexical env when checking method" method-nme (lex/lexical-env))
                                 ;(prn "frees when checking method" 
                                 ;     (into {} (for [[k {:keys [name]}] clojure.core.typed.tvar-env/*current-tvars*]
                                 ;                [k name])))
@@ -1917,7 +1917,7 @@
                                         (fo/-not-filter-at (apply c/Un val-ts)
                                                            (r/ret-o target-ret))
                                         fl/-top))
-                         env-default (update/env+ lex/*lexical-env* [neg-tst-fl] flag+)
+                         env-default (update/env+ (lex/lexical-env) [neg-tst-fl] flag+)
                          _ (when-not @flag+
                              ;; FIXME should we ignore this branch?
                              (u/tc-warning "Local became bottom when checking case default"))]

--- a/module-check/src/main/clojure/clojure/core/typed/check/case.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/case.clj
@@ -1,6 +1,7 @@
 (ns clojure.core.typed.check.case
   (:require [clojure.core.typed.type-rep :as r]
             [clojure.core.typed.utils :as u]
+            [clojure.core.typed.util-vars :as vs]
             [clojure.core.typed.contract-utils :as con]
             [clojure.core.typed.var-env :as var-env]
             [clojure.core.typed.lex-env :as lex]
@@ -18,7 +19,7 @@
   (letfn [(check-case-then [tst-ret {:keys [then] :as case-then}]
             (let [{{fs+ :then} :fl :as rslt} (equiv/tc-equiv := [target-ret tst-ret] nil)
                   flag+ (atom true)
-                  env-thn (update/env+ lex/*lexical-env* [fs+] flag+)
+                  env-thn (update/env+ (lex/lexical-env) [fs+] flag+)
                   _ (when-not @flag+
                       ;; FIXME should we ignore this branch?
                       (u/tc-warning "Local became bottom when checking case then"))

--- a/module-check/src/main/clojure/clojure/core/typed/check/do.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/do.clj
@@ -64,7 +64,7 @@
                           (reduced [nenv (conj cexprs 
                                                (assoc cexpr 
                                                       u/expr-type (r/ret (r/Bottom))))])))))
-                  [lex/*lexical-env* []] (map-indexed vector exprs))
+                  [(lex/lexical-env) []] (map-indexed vector exprs))
           actual-types (map u/expr-type cexprs)
           _ (assert (lex/PropEnv? env))
           _ (assert ((every-pred vector? seq) cexprs)) ; make sure we conj'ed in the right order

--- a/module-check/src/main/clojure/clojure/core/typed/check/fn_method_one.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/fn_method_one.clj
@@ -105,9 +105,9 @@
         ;                                       (symbol? sym)]}
         ;                                (subst-filter p sym obj/-empty true))
         ;                              oldp (map :sym required-params)))
-        ;                    (:props lex/*lexical-env*))
+        ;                    (:props (lex/lexical-env)))
 
-        props (:props lex/*lexical-env*)
+        props (:props (lex/lexical-env))
         crequired-params (map (fn [p t] (assoc p u/expr-type (r/ret t)))
                               required-params
                               (concat dom 
@@ -150,7 +150,7 @@
 
         ;_ (prn "funapp1: inferred mm-filter" mm-filter)
 
-        env (let [env (-> lex/*lexical-env*
+        env (let [env (-> (lex/lexical-env)
                           ;add mm-filter
                           (assoc-in [:props] (set (concat props (when mm-filter [mm-filter]))))
                           ;add parameters to scope

--- a/module-check/src/main/clojure/clojure/core/typed/check/if.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/if.clj
@@ -49,22 +49,22 @@
 
             ;_ (print-env)
             ;idsym (gensym)
-            env-thn (update/env+ lex/*lexical-env* [fs+] flag+)
+            env-thn (update/env+ (lex/lexical-env) [fs+] flag+)
             ;          _ (do (pr "check-if: env-thn")
             ;              (print-env* env-thn))
-            env-els (update/env+ lex/*lexical-env* [fs-] flag-)
+            env-els (update/env+ (lex/lexical-env) [fs-] flag-)
             ;          _ (do (pr "check-if: env-els")
             ;              (print-env* env-els))
             ;          new-thn-props (set
             ;                          (filter atomic-filter?
             ;                                  (set/difference
-            ;                                    (set (:props lex/*lexical-env*))
+            ;                                    (set (:props (lex/lexical-env)))
             ;                                    (set (:props env-thn)))))
             ;_ (prn idsym"env+: new-thn-props" (map unparse-filter new-thn-props))
             ;          new-els-props (set
             ;                          (filter atomic-filter?
             ;                                  (set/difference
-            ;                                    (set (:props lex/*lexical-env*))
+            ;                                    (set (:props (lex/lexical-env)))
             ;                                    (set (:props env-els)))))
             ;_ (prn idsym"env+: new-els-props" (map unparse-filter new-els-props))
             cthen

--- a/module-check/src/main/clojure/clojure/core/typed/check/let.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/let.clj
@@ -105,7 +105,7 @@
                                               (assoc-in [:l sym] t))
                                           (conj cexprs cexpr)])
                      :else (err/int-error (str "What is this?" fl)))))
-               [lex/*lexical-env* []] (map vector bindings (or expected-bnds
+               [(lex/lexical-env) []] (map vector bindings (or expected-bnds
                                                                (repeat nil))))
 
              cbody (var-env/with-lexical-env env

--- a/module-check/src/main/clojure/clojure/core/typed/check/print_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/print_env.clj
@@ -5,7 +5,7 @@
             [clojure.core.typed.parse-unparse :as prs]))
 
 (defn print-env*
-  ([] (print-env* lex/*lexical-env*))
+  ([] (print-env* (lex/lexical-env)))
   ([e]
    {:pre [(lex/PropEnv? e)]}
    ;; DO NOT REMOVE

--- a/module-check/src/main/clojure/clojure/core/typed/check/value.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/value.clj
@@ -12,7 +12,7 @@
             [clojure.core.typed.type-rep :as r]))
 
 (defn flow-for-value []
-  (let [props (:props lex/*lexical-env*)
+  (let [props (:props (lex/lexical-env))
         flow (r/-flow (apply fo/-and fl/-top props))]
     flow))
 

--- a/module-check/src/main/clojure/clojure/core/typed/check_form_common.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check_form_common.clj
@@ -9,6 +9,7 @@
             [clojure.core.typed.type-rep :as r]
             [clojure.core.typed.util-vars :as vs]
             [clojure.core.typed.current-impl :as impl]
+            [clojure.core.typed.lex-env :as lex-env]
             [clojure.core.typed.errors :as err]
             [clojure.core.typed.parse-unparse :as prs])
   (:import (clojure.lang ExceptionInfo)))
@@ -78,7 +79,8 @@
               vs/*already-checked* (atom #{})
               vs/*delayed-errors* (err/-init-delayed-errors)
               vs/*analyze-ns-cache* (cache/soft-cache-factory {})
-              vs/*in-check-form* true]
+              vs/*in-check-form* true
+              vs/*lexical-env* (lex-env/init-lexical-env)]
       (let [expected (or
                        expected-ret
                        (when type-provided?

--- a/module-check/src/main/clojure/clojure/core/typed/check_ns_common.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check_ns_common.clj
@@ -9,6 +9,7 @@
             [clojure.core.typed.file-mapping :as file-map]
             [clojure.core.typed.var-env :as var-env]
             [clojure.core.typed.util-vars :as vs]
+            [clojure.core.typed.lex-env :as lex-env]
             [clojure.core.typed.errors :as err]
             [clojure.core.typed.current-impl :as impl]
             [clojure.core.typed.ns-deps-utils :as ns-deps-u]
@@ -52,7 +53,8 @@
                     vs/*checked-asts* (when (#{impl/clojure} impl)
                                         (when (== 1 (count nsym-coll))
                                           (atom {})))
-                    vs/*already-collected* (atom #{})]
+                    vs/*already-collected* (atom #{})
+                    vs/*lexical-env* (lex-env/init-lexical-env)]
             (let [terminal-error (atom nil)]
               (reset-env/reset-envs!)
               ;(reset-caches)

--- a/module-check/src/main/clojure/clojure/core/typed/indirect_ops.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/indirect_ops.clj
@@ -9,4 +9,5 @@
                      -FS
                      -top-fn
                      -empty-fn
-                     infer)
+                     infer
+                     PropEnv?)

--- a/module-check/src/main/clojure/clojure/core/typed/var_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/var_env.clj
@@ -46,7 +46,7 @@
     env))
 
 (defmacro with-lexical-env [env & body]
-  `(binding [lex/*lexical-env* ~env]
+  `(binding [vs/*lexical-env* ~env]
      ~@body))
 
 (defn var-annotations []

--- a/module-rt/src/main/clojure/clojure/core/typed/util_vars.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/util_vars.clj
@@ -40,3 +40,4 @@
 (defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *delayed-errors* nil)
 (defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *analyze-ns-cache* nil)
 (defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *checked-asts* nil)
+(defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *lexical-env* nil)


### PR DESCRIPTION
With the upcoming support for refinment types, we probably want to inspect
the current lexical environment in type-rep. This moves the existing
*lexical-env* var to util-vars.