### PR TITLE
Add test for CTYP-212

### DIFF
--- a/module-check/src/test/clojure/clojure/core/typed/test/core.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/core.clj
@@ -5031,6 +5031,16 @@
             ^{:baz 1} nme
             {:baz 2} [a] a)))))
 
+(deftest CTYP-212-test
+  (is-tc-e
+    (do
+      (ann-record MyRecord [p :- (Promise Int)])
+
+      (defrecord MyRecord [p])
+
+      (defn foo []
+        (let [x :- (Promise Int) (promise)])))))
+
 ;    (is-tc-e 
 ;      (let [f (fn [{:keys [a] :as m} :- '{:a (U nil Num)}] :- '{:a Num} 
 ;                {:pre [(number? a)]} 


### PR DESCRIPTION
This was fixed sometime between 0.2.84 and 0.3.7. It's unclear
what the exact issue was without further investigation.

Adding a test to close the issue.