### PR TITLE
Support metadata map and :arglists in typed defn (CTYP-168)

### DIFF
--- a/module-rt/src/main/clojure/clojure/core/typed/internal.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/internal.clj
@@ -124,8 +124,16 @@
   (let [[flatopt args] (parse-keyword-flat-map args)
         [name & args] args
         _ (assert (symbol? name) "defn name should be a symbol")
-        [docstring args] (take-when string? args)]
-    {:name (vary-meta name #(merge % (when docstring {:doc docstring})))
+        [docstring args] (take-when string? args)
+        [attr-map args] (take-when map? args)]
+    {:name (vary-meta name merge 
+                      {:arglists
+                       (list 'quote
+                             (if (vector? (first args)) ; arity = 1
+                               (list (first args))
+                               (map first args)))}
+                      (when docstring {:doc docstring})
+                      attr-map)
      :args (concat flatopt args)}))
 
 ;(ann parse-fn> [Any (Seqable Any) ->

--- a/module-rt/src/main/clojure/clojure/core/typed/macros.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/macros.clj
@@ -226,10 +226,8 @@
                ~@args)))
 
 (defmacro
-  ^{:forms '[(defn name docstring? [param :- type *] :- type exprs*)
-             (defn :forall poly name docstring? [param :- type *] :- type exprs*)
-             (defn poly? name docstring? ([param :- type *] :- type exprs*)+)
-             (defn :forall poly name docstring? ([param :- type *] :- type exprs*)+)]}
+  ^{:forms '[(defn kw-args? name docstring? attr-map? [param :- type *] :- type exprs*)
+             (defn kw-args? name docstring? attr-map? ([param :- type *] :- type exprs*)+)]}
   defn
   "Like defn, but expands to clojure.core.typed/fn. If a polymorphic binder is
   supplied before the var name, expands to clojure.core.typed/pfn.


### PR DESCRIPTION
As far as I can tell, these are the last things missing in the typed defn
compared to clojure.core/defn.

Added some tests to ensure the ordering of metadata merging is correct.