### PR TITLE
Add test for CTYP-172

### DIFF
--- a/module-check/src/test/clojure/clojure/core/typed/test/core.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/core.clj
@@ -5101,6 +5101,10 @@
 
       (ann-form [true {}] BaseValidationSchema))))
 
+(deftest CTYP-172-test
+  (is-tc-e (fn [[a b] :- (I (Vec Num) (ExactCount 2))]
+             (+ a b))))
+
 ;    (is-tc-e 
 ;      (let [f (fn [{:keys [a] :as m} :- '{:a (U nil Num)}] :- '{:a Num} 
 ;                {:pre [(number? a)]} 


### PR DESCRIPTION
This test apparently failed sometime before 0.3.8, probably because
`nth` didn't respect the first argument's CountRange, and inferred
that `a` and `b` in this test was `(U nil Num)`.

Adding the test without further investigation.