### PR TITLE
Add test for CTYP-210

### DIFF
--- a/module-check/src/test/clojure/clojure/core/typed/test/core.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/core.clj
@@ -5105,6 +5105,9 @@
   (is-tc-e (fn [[a b] :- (I (Vec Num) (ExactCount 2))]
              (+ a b))))
 
+(deftest CTYP-210-test
+  (is-tc-e #(long (+ 2 (int 123)))))
+
 ;    (is-tc-e 
 ;      (let [f (fn [{:keys [a] :as m} :- '{:a (U nil Num)}] :- '{:a Num} 
 ;                {:pre [(number? a)]} 


### PR DESCRIPTION
The inlining for `long` was overrident to take at least a Number
in f2e027 which fixes this issue.

A test is added to close the issue.