### PR TITLE
CTYP-253 - Remove static/instance flag in check-method

### DIFF
--- a/module-check/src/main/clojure/clojure/core/typed/check.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check.clj
@@ -464,7 +464,7 @@
         r (get/invoke-get expr expected :cargs cargs)]
     (if-not (#{cu/not-special} r)
       r
-      (method/check-invoke-method check expr expected false
+      (method/check-invoke-method check expr expected
                                   :cargs cargs))))
 
 ;FIXME should be the same as (apply hash-map ..) in invoke-apply
@@ -1032,7 +1032,7 @@
         r (nth/invoke-nth check expr expected :cargs cargs)]
     (if-not (#{cu/not-special} r)
       r
-      (method/check-invoke-method check expr expected false
+      (method/check-invoke-method check expr expected
                                   :cargs cargs))))
 
 ;nthnext
@@ -1457,7 +1457,7 @@
   (let [spec (static-method-special expr expected)]
     (if (not= :default spec)
       spec
-      (method/check-invoke-method check expr expected false))))
+      (method/check-invoke-method check expr expected))))
 
 (add-check-method :instance-call
   [expr & [expected]]
@@ -1475,7 +1475,7 @@
   (let [spec (instance-method-special expr expected)]
     (if (not= :default spec)
       spec
-      (method/check-invoke-method check expr expected true))))
+      (method/check-invoke-method check expr expected))))
 
 (add-check-method :static-field
   [expr & [expected]]

--- a/module-check/src/main/clojure/clojure/core/typed/check/method.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/method.clj
@@ -14,16 +14,16 @@
             [clojure.core.typed.method-override-env :as mth-override]))
 
 ;[MethodExpr Type Any -> Expr]
-(defn check-invoke-method [check-fn {c :class method-name :method :keys [args env] :as expr} expected inst?
+(defn check-invoke-method [check-fn {c :class method-name :method :keys [args env] :as expr} expected
                            & {:keys [ctarget cargs method-override]}]
   {:pre [((some-fn nil? r/TCResult?) expected)
-         ((some-fn nil? r/Type?) method-override)
-         (or (not ctarget) inst?)]
+         ((some-fn nil? r/Type?) method-override)]
    :post [(-> % u/expr-type r/TCResult?)
           (vector? (:args %))]}
   (binding [vs/*current-env* env
             vs/*current-expr* expr]
-    (let [method (cu/MethodExpr->Method expr)
+    (let [inst? (= :instance-call (:op expr))
+          method (cu/MethodExpr->Method expr)
           msym (cu/MethodExpr->qualsym expr)
           rfin-type (or method-override
                         (when msym

--- a/module-check/src/main/clojure/clojure/core/typed/check/nth.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/nth.clj
@@ -152,7 +152,7 @@
       ; rewrite nth type to be more useful when we have an exact (and interesting) index.
       (nat-value? num-t)
       (method/check-invoke-method
-        check-fn expr expected false
+        check-fn expr expected
         :method-override (nth-function-type (-> num-t :val))
         :cargs cargs)
       :else cu/not-special)))


### PR DESCRIPTION
Use the expression argument to infer flag.