### PR TITLE
CTYP-254 - Add flag to enable AST rewriting

### DIFF
--- a/module-check/src/main/clojure/clojure/core/typed/check/utils.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check/utils.clj
@@ -501,3 +501,7 @@
                 (when (and (sub/subtype? v1 v2)
                            (not (sub/subtype? v2 v1)))
                   k))))))
+
+(defn should-rewrite? []
+  (and vs/*in-check-form*
+       vs/*can-rewrite*))

--- a/module-check/src/main/clojure/clojure/core/typed/check_form_common.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check_form_common.clj
@@ -80,7 +80,8 @@
               vs/*delayed-errors* (err/-init-delayed-errors)
               vs/*analyze-ns-cache* (cache/soft-cache-factory {})
               vs/*in-check-form* true
-              vs/*lexical-env* (lex-env/init-lexical-env)]
+              vs/*lexical-env* (lex-env/init-lexical-env)
+              vs/*can-rewrite* true]
       (let [expected (or
                        expected-ret
                        (when type-provided?

--- a/module-check/src/main/clojure/clojure/core/typed/check_ns_common.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/check_ns_common.clj
@@ -54,7 +54,9 @@
                                         (when (== 1 (count nsym-coll))
                                           (atom {})))
                     vs/*already-collected* (atom #{})
-                    vs/*lexical-env* (lex-env/init-lexical-env)]
+                    vs/*lexical-env* (lex-env/init-lexical-env)
+                    ;; nested check-ns inside check-form switches off check-form
+                    vs/*in-check-form* false]
             (let [terminal-error (atom nil)]
               (reset-env/reset-envs!)
               ;(reset-caches)

--- a/module-rt/src/main/clojure/clojure/core/typed/util_vars.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/util_vars.clj
@@ -41,3 +41,4 @@
 (defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *analyze-ns-cache* nil)
 (defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *checked-asts* nil)
 (defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *lexical-env* nil)
+(defonce ^{:doc "Internal use only"} ^:skip-wiki ^:dynamic *can-rewrite* nil)


### PR DESCRIPTION
It only makes sense to rewrite the AST when we have full control over
the evaluation of a form. The var *can-rewrite* is true if this is
the case.