### PR TITLE
CTYP-255 - Unparse should be flexible to unknown implementations

### DIFF
--- a/module-check/src/test/clojure/clojure/core/typed/test/ctyp_255.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/ctyp_255.clj
@@ -1,0 +1,19 @@
+(ns clojure.core.typed.test.ctyp-255
+  (:require [clojure.test :refer :all]
+            [clojure.core.typed.parse-unparse :refer :all]
+            [clojure.core.typed.type-rep :as r]
+            [clojure.core.typed.type-ctors :as c]
+            [clojure.core.typed :as t]
+            [clojure.core.typed.test.test-utils :refer :all]))
+
+(deftest ctyp-255-test
+  (testing "unknown implementation of unparse uses clojure.core.typed
+           for special types"
+    (is (= (unparse-type r/-any)
+           'clojure.core.typed/Any)))
+  (testing "unparsing protocols is fully qualified in :unknown"
+    (is (= (unparse-type (cljs (c/Protocol-of 'cljs.core/ISet [r/-any])))
+           '(cljs.core/ISet clojure.core.typed/Any))))
+  (testing "can print a tc-e result with :unknown"
+    (is (do (prn (tc-e 1))
+            true))))

--- a/module-check/src/test/clojure/clojure/core/typed/test/test_utils.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/test_utils.clj
@@ -129,6 +129,9 @@
 (defmacro is-clj [& args]
   `(is (clj ~@args)))
 
+(defmacro cljs [& body]
+  `(impl/with-cljs-impl ~@body))
+
 (defmacro clj [& body]
   `(impl/with-clojure-impl ~@body))
 

--- a/unit-test-for.sh
+++ b/unit-test-for.sh
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+touch module-check/src/test/clojure/clojure/core/typed/test/ctyp_$1.clj
+
+echo "(ns clojure.core.typed.test.ctyp-${1}\n  (:require [clojure.test :refer :all]\n            [clojure.core.typed.test.test-utils :refer :all]))" >> module-check/src/test/clojure/clojure/core/typed/test/ctyp_$1.clj 


### PR DESCRIPTION
The :default implementation is the default if no implementation is
specified. If no :default case is specified in impl-case, an exception
is thrown as before.