### PR TITLE
CTYP-256 - Extend impl-case with :unknown implementation

### DIFF
--- a/module-check/src/test/clojure/clojure/core/typed/test/core.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/core.clj
@@ -5108,6 +5108,27 @@
 (deftest CTYP-210-test
   (is-tc-e #(long (+ 2 (int 123)))))
 
+(deftest CTYP-256-test
+  (is (= (impl/with-clojure-impl
+           (impl/impl-case
+             :clojure 1
+             :cljs 2))
+         1))
+  (is (= (impl/with-cljs-impl
+           (impl/impl-case
+             :clojure 1
+             :cljs 2))
+         2))
+  (is (= (impl/impl-case
+           :clojure 1
+           :cljs 2
+           :unknown 3)
+         3))
+  (is (thrown? AssertionError
+               (impl/impl-case
+                 :clojure 1
+                 :cljs 2))))
+
 ;    (is-tc-e 
 ;      (let [f (fn [{:keys [a] :as m} :- '{:a (U nil Num)}] :- '{:a Num} 
 ;                {:pre [(number? a)]} 

--- a/module-rt/src/main/clojure/clojure/core/typed/current_impl.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/current_impl.clj
@@ -37,11 +37,11 @@
 (derive clojure any-impl)
 (derive clojurescript any-impl)
 
-(defonce ^:dynamic *current-impl* nil)
-(set-validator! #'*current-impl* (some-fn nil? keyword?))
+(defonce ^:dynamic *current-impl* :unknown)
+(set-validator! #'*current-impl* keyword?)
 
 (defmacro with-impl [impl & body]
-  `(do (assert ((some-fn #{~impl} nil?) *current-impl*) 
+  `(do (assert ((set [~impl :unknown]) *current-impl*) 
                (str "Cannot overlay different core.typed implementations: " (pr-str *current-impl*)
                     ", expected " (pr-str ~impl)))
      (binding [*current-impl* ~impl]
@@ -114,7 +114,7 @@
 
 
 (defn implementation-specified? []
-  (boolean *current-impl*))
+  ((complement #{:unknown}) *current-impl*))
 
 (defn ensure-impl-specified []
   (assert (implementation-specified?) "No implementation specified"))
@@ -140,13 +140,15 @@
 (defn assert-cljs []
   (assert (= clojurescript *current-impl*) "Clojurescript implementation only"))
 
-(defmacro impl-case [& {clj-case :clojure cljs-case :cljs :as opts}]
-  (assert (= #{:clojure :cljs} (set (keys opts)))
+(defmacro impl-case [& {clj-case :clojure cljs-case :cljs unknown :unknown :as opts}]
+  (assert (empty? (set/difference (set (keys opts)) #{:clojure :cljs :unknown}))
           "Incorrect cases to impl-case")
-  `(case (current-impl)
+  `(case *current-impl*
      ~clojure ~clj-case
      ~clojurescript ~cljs-case
-     (assert nil (str "No case matched for impl-case" (current-impl)))))
+     ~(if (contains? opts :unknown)
+        unknown
+        `(assert nil (str "No case matched for impl-case " *current-impl*)))))
 
 (defn var->symbol [^clojure.lang.Var var]
   {:pre [(var? var)]


### PR DESCRIPTION
The :unknown implementation is the default if no implementation is
specified. If no :unknown case is specified in impl-case and the
impl-case falls through, an exception is thrown as before.

Also add impl-case tests.