### PR TITLE
CTYP-260 - Alter Queue and BlockingQueue types

### DIFF
--- a/module-check/src/main/clojure/clojure/core/typed/base_env_clj_rclass.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/base_env_clj_rclass.clj
@@ -470,6 +470,20 @@ java.util.RandomAccess [[[a :variance :covariant]]
                         :unchecked-ancestors
                         #{(Indexed a)}]
 
+java.util.Queue [[[a :variance :covariant]]
+                 :replace
+                 {Iterable (Iterable a)
+                  Collection (Collection a)}
+                 :unchecked-ancestors
+                 #{(Seqable a)}]
+
+java.util.concurrent.BlockingQueue [[[a :variance :covariant]]
+                                    :replace
+                                    {Iterable (Iterable a)
+                                     java.util.Queue (java.util.Queue a)
+                                     Collection (Collection a)}
+                                    :unchecked-ancestors
+                                    #{(Seqable a)}]
 ))
 
 (defn reset-rclass-env! []

--- a/module-check/src/test/clojure/clojure/core/typed/test/ctyp_260.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/ctyp_260.clj
@@ -1,0 +1,21 @@
+(ns clojure.core.typed.test.ctyp-260
+  (:require [clojure.test :refer :all]
+            [clojure.core.typed.test.test-utils :refer :all]))
+
+(deftest motivating-use-case
+  "This prompted CTYP-260 in the first place."
+  (is-tc-e (t/fn [q :- (java.util.Queue String)] (first q))
+           [(java.util.Queue String) -> (t/Option String)])
+  (is-tc-e (t/fn [q :- (java.util.concurrent.BlockingQueue String)] (first q))
+           [(java.util.concurrent.BlockingQueue String) -> (t/Option String)]))
+
+(deftest type-params
+  "Queue and BlockingQueue should have type params."
+  (is-tc-e (t/ann-form (java.util.LinkedList. [1 2 3]) (java.util.Queue t/Any)))
+  (is-tc-e (t/ann-form (java.util.concurrent.LinkedBlockingQueue. [1 2 3]) (java.util.concurrent.BlockingQueue t/Any))))
+
+(deftest seqable
+  "Queue and BlockingQueue are both (Seqable a)"
+  (is-tc-e (t/ann-form (java.util.LinkedList. [1 2 3]) (t/Seqable t/Any)))
+  (is-tc-e (t/ann-form (java.util.concurrent.LinkedBlockingQueue. [1 2 3]) (t/Seqable t/Any))))
+


### PR DESCRIPTION
Goal: have core.typed recognize that a (BlockingQueue a) is a valid
annotation and is also a (Seqable a).

(Not sure about my approach for the tests -- pieced together by looking mainly at clojure.core.typed.test.core.)
