### PR TITLE
CTYP-269: Combine mutable environments into one atom

### DIFF
--- a/module-check/src/main/clojure/clojure/core/typed/base_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/base_env.clj
@@ -137,7 +137,7 @@ clojure.core.typed/check-ns (IFn [Symbol -> Any]
                                 [-> Any])
 ;; Internal annotations
 
-clojure.core.typed.current-impl/*current-impl* Any
+;clojure.core.typed.current-impl/*current-impl* Any
 clojure.core.typed.current-impl/clojure Any
 clojure.core.typed.current-impl/clojurescript Any
 clojure.core.typed/ann* [Any Any Any -> Any]

--- a/module-check/src/main/clojure/clojure/core/typed/collect_cljs.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/collect_cljs.clj
@@ -174,8 +174,8 @@
 (defmethod invoke-special-collect 'cljs.core.typed/ann-jsnominal*
   [{:keys [args env] :as expr}]
   (let [[sym jsnom] (map :form args)]
-    (swap! impl/jsnominal-env
-      assoc sym
+    (impl/add-jsnominal-env
+      sym
       (second (beh-cljs/jsnominal-entry [sym jsnom])))))
 
 (defmethod invoke-special-collect 'cljs.core.typed/ann-protocol*

--- a/module-check/src/main/clojure/clojure/core/typed/cs_gen.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/cs_gen.clj
@@ -41,7 +41,6 @@
 (t/ann ^:no-check clojure.core.typed.subtype/subtype? [r/AnyType r/AnyType -> Boolean])
 (t/ann ^:no-check clojure.set/union (t/All [x] [(t/Set x) * -> (t/Set x)]))
 (t/ann ^:no-check clojure.core.typed.current-impl/current-impl [-> t/Any])
-(t/ann ^:no-check clojure.core.typed.current-impl/any-impl t/Any)
 (t/ann ^:no-check clojure.core.typed.current-impl/checking-clojure? [-> t/Any])
 
 (t/ann subtype? [r/AnyType r/AnyType -> Boolean])

--- a/module-check/src/main/clojure/clojure/core/typed/datatype_ancestor_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/datatype_ancestor_env.clj
@@ -5,6 +5,8 @@
             [clojure.core.typed.type-ctors :as c]
             [clojure.core.typed.subst :as subst]
             [clojure.core.typed :as t]
+            [clojure.core.typed.env :as env]
+            [clojure.core.typed.nilsafe-utils :as nilsafe]
             [clojure.set :as set])
   (:import (clojure.core.typed.type_rep DataType)))
 
@@ -22,67 +24,49 @@
   "Environment mapping datatype names to sets of ancestor types."
   (t/Map t/Sym (t/Set r/ScopedType)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Predicates
+(def tset? (con/set-c? (some-fn r/Scope? r/Type?)))
+(def dt-ancestor-env? (con/hash-c? symbol? tset?))
 
-(def ^:no-check ^{:ann '[Any -> Any]}
-  dt-ancestor-env? (con/hash-c? symbol? (con/set-c? (some-fn r/Scope? r/Type?))))
+(def current-dt-ancestors-kw ::current-dt-ancestors)
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Implementation specific global state
-
-(t/ann CLJ-DT-ANCESTOR-ENV (t/Atom1 DTAncestorEnv))
-(defonce ^:private CLJ-DT-ANCESTOR-ENV ((t/inst atom DTAncestorEnv) {} :validator dt-ancestor-env?))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Implementation agnostic state
-
-(t/ann ^:no-check *current-dt-ancestors* (t/U nil (t/Atom1 DTAncestorEnv)))
-(defonce ^:dynamic 
-  *current-dt-ancestors* nil)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Helpers
-
-(defn ^:private ^{:ann '[-> Any]}
-  assert-dt-ancestors []
-  (assert *current-dt-ancestors* "No datatype ancestor environment bound"))
-
-(defn ^:private ^{:ann '[DataType (t/U nil (t/Seqable r/Type)) -> (t/Set r/Type)]}
-  inst-ancestors
+(t/ann ^:no-check inst-ancestors [DataType (t/U nil (t/Seqable r/Type)) -> (t/Set r/Type)])
+(defn inst-ancestors
   "Given a datatype, return its instantiated ancestors"
   [{poly :poly? :as dt} anctrs]
   {:pre [(r/DataType? dt)]
    :post [((con/set-c? r/Type?) %)]}
-  (set (t/for [u :- r/Type, anctrs] :- r/Type
-         (c/inst-and-subst u poly))))
+  (into #{}
+        (map #(c/inst-and-subst % poly))
+        anctrs))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interface
 
-(defn ^:no-check ^{:ann '[DataType -> (t/Set r/Type)]}
-  get-datatype-ancestors 
+(defn all-dt-ancestors []
+  {:post [(map? %)]}
+  (get (env/deref-checker) current-dt-ancestors-kw {}))
+
+(t/ann ^:no-check get-datatype-ancestors [DataType -> (t/Set r/Type)])
+(defn get-datatype-ancestors 
   "Returns the set of overriden ancestors of the given DataType."
   [{:keys [poly? the-class] :as dt}]
   {:pre [(r/DataType? dt)]}
-  (assert-dt-ancestors)
-  (t/when-let-fail [a *current-dt-ancestors*]
-    (inst-ancestors dt (@a the-class))))
+  (inst-ancestors dt (get (all-dt-ancestors) the-class)))
 
-(defn ^:no-check ^{:ann '[t/Sym (t/Set r/Type) -> nil]}
-  add-datatype-ancestors 
+(t/ann ^:no-check add-datatype-ancestors [t/Sym (t/Set r/Type) -> nil])
+(defn add-datatype-ancestors 
   "Add a set of ancestor overrides for the datatype named sym."
   [sym tset]
-  (assert-dt-ancestors)
-  (t/when-let-fail [a *current-dt-ancestors*]
-    (swap! a update-in [sym] #(set/union (or % #{}) tset)))
+  {:pre [(symbol? sym)
+         (tset? tset)]
+   :post [(nil? %)]}
+  (env/swap-checker! update-in [current-dt-ancestors-kw sym] nilsafe/set-union tset)
   nil)
 
-(defn ^:no-check ^{:ann '[DTAncestorEnv -> nil]}
-  reset-datatype-ancestors! 
+(t/ann ^:no-check reset-datatype-ancestors! [DTAncestorEnv -> nil])
+(defn reset-datatype-ancestors! 
   "Reset the current ancestor map."
   [aenv]
-  (assert-dt-ancestors)
-  (t/when-let-fail [a *current-dt-ancestors*]
-    (reset! a aenv))
+  {:pre [(dt-ancestor-env? aenv)]}
+  (env/swap-checker! assoc current-dt-ancestors-kw aenv)
   nil)

--- a/module-check/src/main/clojure/clojure/core/typed/declared_kind_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/declared_kind_env.clj
@@ -1,52 +1,47 @@
 (ns clojure.core.typed.declared-kind-env
   (:require [clojure.core.typed.contract-utils :as con]
             [clojure.core.typed.errors :as err]
-            [clojure.core.typed.type-rep :as r]))
+            [clojure.core.typed.type-rep :as r]
+            [clojure.core.typed.env :as env]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Declared kind Env
 
-(defonce ^:dynamic *current-declared-kinds* nil)
+(def declared-kind-env? (con/hash-c? symbol? r/TypeFn?))
 
-(defn assert-declared-kinds []
-  (assert *current-declared-kinds* "No declared kinds bound"))
+(def current-declared-kinds-kw ::current-declared-kinds)
 
-(defonce CLJ-DECLARED-KIND-ENV (atom {}))
-(set-validator! CLJ-DECLARED-KIND-ENV (con/hash-c? symbol? r/TypeFn?))
-
-(defonce CLJS-DECLARED-KIND-ENV (atom {}))
-(set-validator! CLJS-DECLARED-KIND-ENV (con/hash-c? symbol? r/TypeFn?))
+(defn declared-kinds []
+  {:post [(map? %)]}
+  (get (env/deref-checker) current-declared-kinds-kw {}))
 
 (defn reset-declared-kinds! [m]
-  (assert-declared-kinds)
-  (reset! *current-declared-kinds* m))
+  {:pre [(declared-kind-env? m)]
+   :post [(nil? %)]}
+  (env/swap-checker! assoc current-declared-kinds-kw m)
+  nil)
 
 (defn add-declared-kind [sym tfn]
   {:pre [(symbol? sym)
-         (r/TypeFn? tfn)]}
-  (assert-declared-kinds)
-  (swap! *current-declared-kinds* assoc sym tfn)
+         (r/TypeFn? tfn)]
+   :post [(nil? %)]}
+  (env/swap-checker! assoc-in [current-declared-kinds-kw sym] tfn)
   nil)
 
 (defn declared-kind-or-nil [sym]
-  (assert-declared-kinds)
-  (@*current-declared-kinds* sym))
+  (get (declared-kinds) sym))
 
 (defn get-declared-kind [sym]
-  (assert-declared-kinds)
   (if-let [tfn (declared-kind-or-nil sym)]
     tfn
     (err/int-error (str "No declared kind for Name " sym))))
 
 (defn has-declared-kind? [sym]
-  (assert-declared-kinds)
   (boolean (declared-kind-or-nil sym)))
 
 (defn remove-declared-kind [sym]
-  (assert-declared-kinds)
-  (swap! *current-declared-kinds* dissoc sym)
+  (env/swap-checker! update current-declared-kinds-kw dissoc sym)
   nil)
 
 (defn declare-alias-kind* [sym ty]
-  (assert-declared-kinds)
   (add-declared-kind sym ty))

--- a/module-check/src/main/clojure/clojure/core/typed/init.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/init.clj
@@ -44,6 +44,7 @@
                  '[clojure.core.typed.var-env]
                  '[clojure.core.typed.parse-unparse]
                  '[clojure.core.typed.current-impl]
+                 '[clojure.core.typed.env]
                  '[clojure.core.typed.dvar-env]
                  '[clojure.core.typed.datatype-ancestor-env]
                  '[clojure.core.typed.datatype-env]

--- a/module-check/src/main/clojure/clojure/core/typed/ns_deps.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/ns_deps.clj
@@ -3,7 +3,8 @@
             [clojure.core.typed.contract-utils :as con]
             [clojure.core.typed.current-impl :as impl]
             [clojure.core.typed.nilsafe-utils :as nilsafe]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [clojure.core.typed.env :as env]))
 
 (t/tc-ignore
 (alter-meta! *ns* assoc :skip-wiki true)
@@ -13,59 +14,45 @@
   "A map declaring possibly-circular namespace dependencies."
   (t/Map t/Sym (t/Set t/Sym)))
 
+(t/ann ^:no-check dep-map? [t/Any -> t/Any])
+(def dep-map? (con/hash-c? symbol? (con/set-c? symbol?)))
+
+(def current-deps-kw ::current-deps)
+
 (t/ann init-deps [-> DepMap])
 (defn init-deps [] 
   {})
 
-(t/ann *current-deps* (t/U nil (t/Atom1 DepMap)))
-(defonce ^:dynamic *current-deps* nil)
-
-(t/ann assert-dep-map [-> (t/Atom1 DepMap)])
-(defn assert-dep-map []
-  (let [d *current-deps*]
-    (assert d "No current namespace dependencies")
-    d))
-
-(t/ann current-deps [-> (t/Atom1 DepMap)])
-(defn current-deps []
-  {:post [%]}
-  (let [d (assert-dep-map)]
-    d))
-
-(t/ann ^:no-check dep-map? [t/Any -> t/Any])
-(def dep-map? (con/hash-c? symbol? (con/set-c? symbol?)))
-
-(t/ann CLJ-TYPED-DEPS (t/Atom1 DepMap))
-(defonce CLJ-TYPED-DEPS (atom (init-deps) :validator dep-map?))
-
-(t/ann CLJS-TYPED-DEPS (t/Atom1 DepMap))
-(defonce CLJS-TYPED-DEPS (atom (init-deps) :validator dep-map?))
+(t/ann ^:no-check deps [-> DepMap])
+(defn deps []
+  {:post [(map? %)]}
+  (get (env/deref-checker) current-deps-kw {}))
 
 (t/ann ^:no-check add-ns-deps [t/Sym (t/Set t/Sym) -> DepMap])
 (defn add-ns-deps [nsym deps]
   {:pre [(symbol? nsym)
          ((con/set-c? symbol?) deps)]
-   :post [(dep-map? %)]}
-  (swap! (current-deps) update-in [nsym] nilsafe/set-union deps))
+   :post [(nil? %)]}
+  (env/swap-checker! update-in [current-deps-kw nsym] nilsafe/set-union deps)
+  nil)
 
 (t/ann ^:no-check remove-ns-deps [t/Sym (t/Set t/Sym) -> DepMap])
 (defn remove-ns-deps [nsym deps]
   {:pre [(symbol? nsym)
          ((con/set-c? symbol?) deps)]
-   :post [(dep-map? %)]}
-  (swap! (current-deps) update-in [nsym] nilsafe/set-difference deps))
+   :post [(nil? %)]}
+  (env/swap-checker! update-in [current-deps-kw nsym] nilsafe/set-difference deps)
+  nil)
 
-(t/ann immediate-deps [t/Sym -> (t/Set t/Sym)])
+(t/ann ^:no-check immediate-deps [t/Sym -> (t/Set t/Sym)])
 (defn immediate-deps [target-ns]
   {:pre [(symbol? target-ns)]
-   :post [(t/tc-ignore
-            ((con/set-c? symbol?) %))]}
-  (or (@(current-deps) target-ns)
-      #{}))
+   :post [((con/set-c? symbol?) %)]}
+  (get (deps) target-ns #{}))
 
-(t/ann reset-deps! [-> DepMap])
+(t/ann ^:no-check reset-deps! [-> DepMap])
 (defn reset-deps! []
-  (reset! (current-deps) (init-deps)))
+  (env/swap-checker! assoc current-deps-kw (init-deps)))
 
 (t/ann typed-deps [t/Sym -> (t/Set t/Sym)])
 (defn typed-deps [nsym]

--- a/module-check/src/main/clojure/clojure/core/typed/protocol_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/protocol_env.clj
@@ -5,7 +5,8 @@
             [clojure.core.typed.errors-ann]
             [clojure.core.typed.util-vars :as vs]
             [clojure.core.typed.type-rep :as r]
-            [clojure.core.typed :as t]))
+            [clojure.core.typed :as t]
+            [clojure.core.typed.env :as env]))
 
 (t/tc-ignore
 (alter-meta! *ns* assoc :skip-wiki true)
@@ -18,39 +19,29 @@
   "A map mapping protocol symbols their types."
   (t/Map t/Sym r/Type))
 
-(t/ann *current-protocol-env* (t/U nil (t/Atom1 ProtocolEnv)))
-(defonce ^:dynamic *current-protocol-env* nil)
+(def current-protocol-env-kw ::current-protocol-env)
 
 (t/ann protocol-env? [t/Any -> t/Any])
 (def protocol-env? (con/hash-c? #(when (symbol? %)
                                    (namespace %)) 
                                 (some-fn r/Protocol? r/TypeFn?)))
 
-(t/ann CLJ-PROTOCOL-ENV (t/Atom1 ProtocolEnv))
-(defonce CLJ-PROTOCOL-ENV (atom {} :validator protocol-env?))
+(t/ann ^:no-check protocol-env [-> ProtocolEnv])
+(defn protocol-env []
+  {:post [(protocol-env? %)]}
+  (get (env/deref-checker) current-protocol-env-kw {}))
 
-(t/ann CLJS-PROTOCOL-ENV (t/Atom1 ProtocolEnv))
-(defonce CLJS-PROTOCOL-ENV (atom {} :validator protocol-env?))
-
-(t/ann assert-protocol-env [-> t/Any])
-(defn assert-protocol-env []
-  (assert *current-protocol-env* "No current protocol env"))
-
-(t/ann reset-protocol-env! [ProtocolEnv -> nil])
+(t/ann ^:no-check reset-protocol-env! [ProtocolEnv -> nil])
 (defn reset-protocol-env! [e]
-  (assert-protocol-env)
-  (t/when-let-fail [env *current-protocol-env*]
-    (reset! env e))
+  {:pre [(protocol-env? e)]}
+  (env/swap-checker! assoc current-protocol-env-kw e)
   nil)
 
-(t/ann add-protocol [t/Sym r/Type -> nil])
+(t/ann ^:no-check add-protocol [t/Sym r/Type -> nil])
 (defn add-protocol [sym t]
-  ;(prn "add-protocol" sym t)
-  (assert-protocol-env)
-  (t/when-let-fail [e *current-protocol-env*]
-    (let [swap!' (t/inst swap! ProtocolEnv ProtocolEnv t/Sym r/Type)
-          assoc' (t/inst assoc t/Sym r/Type t/Any)]
-      (swap!' e assoc' sym t)))
+  {:pre [(symbol? sym)
+         (r/Type? t)]}
+  (env/swap-checker! assoc-in [current-protocol-env-kw sym] t)
   nil)
 
 (t/ann get-protocol [t/Sym -> (t/U nil r/Type)])
@@ -58,16 +49,15 @@
   "Returns the protocol with var symbol sym.
   Returns nil if not found."
   [sym]
-  (assert-protocol-env)
-  (t/when-let-fail [e *current-protocol-env*]
-    (@e sym)))
+  {:pre [(symbol? sym)]
+   :post [((some-fn nil? r/Type?) %)]}
+  (get (protocol-env) sym))
 
 (t/ann resolve-protocol [t/Sym -> r/Type])
 (defn resolve-protocol [sym]
-  (assert-protocol-env)
+  {:post [(r/Type? %)]}
   (let [p (get-protocol sym)]
     (when-not p 
       (err/int-error (str "Could not resolve Protocol: " sym
                           "\n\nHint: Add protocol annotations with ann-protocol")))
     p))
-

--- a/module-check/src/main/clojure/clojure/core/typed/statistics.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/statistics.clj
@@ -32,11 +32,9 @@
               (conj stats
                     [nsym
                      {:vars {:all-vars (all-defs-in-ns ns)
-                             :no-checks (let [; deref the atom
-                                              all-no-checks @var-env/CLJ-NOCHECK-VAR?]
+                             :no-checks (let [all-no-checks (var-env/clj-nocheck-var?)]
                                           (filter (fn [s] (= (namespace s) nsym)) all-no-checks))
-                             :var-annotations (let [; deref the atom
-                                                    annots @var-env/CLJ-VAR-ANNOTATIONS]
+                             :var-annotations (let [annots (var-env/clj-var-annotations)]
                                                 (->> annots
                                                      (filter (fn [[k v]] (= (namespace k) (str nsym))))
                                                      (map (fn [[k v]] [k (binding [vs/*verbose-types* true]

--- a/module-check/src/main/clojure/clojure/core/typed/var_env.clj
+++ b/module-check/src/main/clojure/clojure/core/typed/var_env.clj
@@ -6,39 +6,43 @@
             [clojure.core.typed.util-vars :as vs]
             [clojure.core.typed.current-impl :as impl]
             [clojure.core.typed :as t]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [clojure.core.typed.env :as env]))
 
-(defonce ^:dynamic *current-var-annotations* nil)
+(def current-var-annotations-kw ::current-var-annotations)
+(def current-nocheck-var?-kw ::current-nocheck-var?)
+(def current-used-vars-kw ::current-used-vars)
+(def current-checked-var-defs-kw ::current-checked-var-defs)
+
 (defonce ^:dynamic *current-nocheck-var?* nil)
 (defonce ^:dynamic *current-used-vars* nil)
 (defonce ^:dynamic *current-checked-var-defs* nil)
 
-(defonce CLJ-VAR-ANNOTATIONS (atom {} :validator (con/hash-c? (every-pred symbol? namespace) (some-fn delay? r/Type?))))
-(defonce CLJ-NOCHECK-VAR? (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
-(defonce CLJ-USED-VARS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
-(defonce CLJ-CHECKED-VAR-DEFS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
+(defn clj-var-annotations []
+  (get @(impl/clj-checker) current-var-annotations-kw {}))
+
+(defn clj-nocheck-var? []
+  (get @(impl/clj-checker) current-nocheck-var?-kw {}))
+
+(defn clj-used-vars []
+  (get @(impl/clj-checker) current-used-vars-kw {}))
+
+(def var-annotations-con (con/hash-c? (every-pred symbol? namespace) (some-fn delay? r/Type?)))
+(def nocheck-var-con (con/set-c? (every-pred symbol? namespace)))
+(def used-vars-con (con/set-c? (every-pred symbol? namespace)))
+(def checked-var-defs-con (con/set-c? (every-pred symbol? namespace)))
+
+;(defonce CLJ-VAR-ANNOTATIONS (atom {} :validator (con/hash-c? (every-pred symbol? namespace) (some-fn delay? r/Type?))))
+;(defonce CLJ-NOCHECK-VAR? (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
+;(defonce CLJ-USED-VARS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
+;(defonce CLJ-CHECKED-VAR-DEFS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
 
 (defonce CLJS-VAR-ANNOTATIONS (atom {} :validator (con/hash-c? (every-pred symbol? namespace) r/Type?)))
-(defonce CLJS-NOCHECK-VAR? (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
-(defonce CLJS-USED-VARS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
-(defonce CLJS-CHECKED-VAR-DEFS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
+;(defonce CLJS-NOCHECK-VAR? (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
+;(defonce CLJS-USED-VARS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
+;(defonce CLJS-CHECKED-VAR-DEFS (atom #{} :validator (con/set-c? (every-pred symbol? namespace))))
 
 (defonce CLJS-JSVAR-ANNOTATIONS (atom {} :validator (con/hash-c? symbol? r/Type?)))
-
-(defn current-var-annotations []
-  (let [env *current-var-annotations*]
-    (assert env "No var annotations env bound")
-    env))
-
-(defn current-nocheck-var? []
-  (let [env *current-nocheck-var?*]
-    (assert env "No var nocheck env bound")
-    env))
-
-(defn current-used-vars []
-  (let [env *current-used-vars*]
-    (assert env "No used var env bound")
-    env))
 
 (defn current-checked-var-defs []
   (let [env *current-checked-var-defs*]
@@ -50,72 +54,96 @@
      ~@body))
 
 (defn var-annotations []
-  @(current-var-annotations))
+  {:post [(map? %)]}
+  (get (env/deref-checker) current-var-annotations-kw {}))
 
 (defn var-no-checks []
-  @(current-nocheck-var?))
+  {:post [(set? %)]}
+  (get (env/deref-checker) current-nocheck-var?-kw #{}))
 
 (defn used-vars []
-  @(current-used-vars))
+  {:post [(set? %)]}
+  (get (env/deref-checker) current-used-vars-kw #{}))
 
 (defn checked-vars []
-  @(current-checked-var-defs))
+  {:post [(set? %)]}
+  (get (env/deref-checker) current-checked-var-defs-kw #{}))
 
 (defn add-var-type [sym type]
-  (when-let [old-t (@(current-var-annotations) sym)]
+  (when-let [old-t ((var-annotations) sym)]
     (when (not= old-t type)
       (println "WARNING: Duplicate var annotation: " sym)
       (flush)))
-  (swap! (current-var-annotations) assoc sym type)
+  (env/swap-checker! assoc-in [current-var-annotations-kw sym] type)
   nil)
 
 (defn check-var? [sym]
-  (not (contains? @(current-nocheck-var?) sym)))
+  (not (contains? (var-no-checks) sym)))
 
 (defn checked-var-def? [sym]
-  (contains? @(current-checked-var-defs) sym))
+  (contains? (checked-vars) sym))
 
 (defn used-var? [sym]
-  (contains? @(current-used-vars) sym))
+  (contains? (used-vars) sym))
 
 (defn add-nocheck-var [sym]
-  (swap! (current-nocheck-var?) conj sym)
+  (env/swap-checker! update current-nocheck-var?-kw (fnil conj #{}) sym)
   nil)
 
 (defn remove-nocheck-var [sym]
-  (swap! (current-nocheck-var?) disj sym)
+  (env/swap-checker! update current-nocheck-var?-kw (fnil disj #{}) sym)
   nil)
 
 (defn add-used-var [sym]
-  (swap! (current-used-vars) conj sym)
+  (env/swap-checker! update current-used-vars-kw (fnil conj #{}) sym)
   nil)
 
 (defn add-checked-var-def [sym]
-  (swap! (current-checked-var-defs) conj sym)
+  (env/swap-checker! update current-checked-var-defs-kw (fnil conj #{}) sym)
   nil)
 
 (defn vars-with-unchecked-defs []
-  (set/difference @(current-used-vars)
-                  @(current-checked-var-defs)
-                  @(current-nocheck-var?)))
+  (set/difference (used-vars)
+                  (checked-vars)
+                  (var-no-checks)))
+
+(defn reset-current-var-annotations! [m]
+  (env/swap-checker! assoc current-var-annotations-kw m)
+  nil)
+
+(defn reset-current-nocheck-var?! [nocheck]
+  (env/swap-checker! assoc current-nocheck-var?-kw nocheck)
+  nil)
+
+(defn reset-current-used-vars! [s]
+  (env/swap-checker! assoc current-used-vars-kw s)
+  nil)
+
+(defn reset-current-checked-var-defs! [s]
+  (env/swap-checker! assoc current-checked-var-defs-kw s)
+  nil)
 
 (defn reset-var-type-env! [m nocheck]
-  (reset! (current-var-annotations) m)
-  (reset! (current-nocheck-var?) nocheck)
-  (reset! (current-used-vars) #{})
-  (reset! (current-checked-var-defs) #{})
+  (reset-current-var-annotations! m)
+  (reset-current-nocheck-var?! nocheck)
+  (reset-current-used-vars! #{})
+  (reset-current-checked-var-defs! #{})
   nil)
 
 (defn reset-jsvar-type-env! [m]
   (reset! CLJS-JSVAR-ANNOTATIONS m)
   nil)
 
+(defn jsvar-annotations []
+  {:post [%]}
+  @CLJS-JSVAR-ANNOTATIONS)
+
 (defn lookup-Var-nofail [nsym]
   {:post [((some-fn nil? r/Type?) %)]}
-  (or (let [e (current-var-annotations)]
-        (force (@e nsym)))
+  (or (let [e (var-annotations)]
+        (force (e nsym)))
       (when (impl/checking-clojurescript?)
-        (@CLJS-JSVAR-ANNOTATIONS nsym))))
+        ((jsvar-annotations) nsym))))
 
 (defn lookup-Var [nsym]
   {:post [((some-fn nil? r/Type?) %)]}

--- a/module-rt/src/main/clojure/clojure/core/typed/ast_ops.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/ast_ops.clj
@@ -6,7 +6,7 @@
 
 (defn resolve-Name [{:keys [name] :as expr}]
   {:pre [(#{:Name} (:op expr))]}
-  (let [e (force (@impl/alias-env name))
+  (let [e (force (get (impl/alias-env) name))
         _ (when-not e
             (err/int-error (str "No alias found for " name)))]
     e))

--- a/module-rt/src/main/clojure/clojure/core/typed/env.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/env.clj
@@ -1,0 +1,31 @@
+(ns clojure.core.typed.env)
+
+(def ^:dynamic *checker* nil)
+
+(defn checker-or-nil []
+  {:post [(or (instance? clojure.lang.IAtom %)
+              (nil? %))]}
+  *checker*)
+
+(defn checker []
+  (let [c *checker*]
+    (assert (instance? clojure.lang.IAtom c) (str "No checker state: " (pr-str c)))
+    c))
+
+(defn empty-checker []
+  {})
+
+(defn init-checker []
+  (atom (empty-checker)
+        :validator map?))
+
+(defn deref-checker []
+  {:post [(map? %)]}
+  @(checker))
+
+(defn swap-checker! [& args]
+  (apply swap! (checker) args))
+
+(defmacro with-checker [c & body]
+  `(binding [*checker* ~c]
+     ~@body))

--- a/module-rt/src/main/clojure/clojure/core/typed/parse_ast.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/parse_ast.clj
@@ -13,7 +13,7 @@
 (t/ann *parse-type-in-ns* (t/U nil t/Sym))
 (defonce ^:dynamic *parse-type-in-ns* nil)
 
-(t/ann ^:no-check clojure.core.typed.current-impl/*current-impl* (t/U nil t/Kw))
+;(t/ann ^:no-check clojure.core.typed.current-impl/*current-impl* (t/U nil t/Kw))
 (t/ann ^:no-check clojure.core.typed.current-impl/current-impl [-> t/Kw])
 
 (t/ann parse-in-ns [-> t/Sym])
@@ -1042,10 +1042,10 @@
                                    (resolve-type-clj sym))]
                          (cond 
                            (class? res) (let [csym (coerce/Class->symbol res)
-                                              dt? (contains? @impl/datatype-env csym)]
+                                              dt? (contains? (impl/datatype-env) csym)]
                                           {:op (if dt? :DataType :Class) :name csym})
                            (var? res) (let [vsym (coerce/var->symbol res)]
-                                        (if (contains? @impl/alias-env vsym)
+                                        (if (contains? (impl/alias-env) vsym)
                                           {:op :Name :name vsym}
                                           {:op :Protocol :name vsym}))
                            (symbol? sym)
@@ -1053,7 +1053,7 @@
                            ; assume it's in the current namespace
                                     ; do we want to munge the sym also?
                            (let [qname (symbol (str (namespace-munge *ns*) "." sym))]
-                             (when (contains? @impl/datatype-env qname)
+                             (when (contains? (impl/datatype-env) qname)
                                {:op :DataType :name qname}))
                            ))
               :cljs (assert nil)

--- a/module-rt/src/main/clojure/clojure/core/typed/type_contract.clj
+++ b/module-rt/src/main/clojure/clojure/core/typed/type_contract.clj
@@ -32,7 +32,7 @@
                           (gen-inner (update-in t [:rator] ops/resolve-Name) arg)
                           ;polymorphic class
                           (#{:Class} (:op rator))
-                            (let [{:keys [args pred] :as rcls} (@impl/rclass-env (:name rator))
+                            (let [{:keys [args pred] :as rcls} (get (impl/rclass-env) (:name rator))
                                   _ (when-not rcls
                                       (err/int-error (str "Class does not take arguments: "
                                                           (:name rator))))


### PR DESCRIPTION
We create an atom for the CLJ and CLJS implementations
in clojure.core.typed.current-impl and holds all the type
checker state for those implementations.

clojure.core.typed.env/*checker* is a dynamic binding that holds
the current implementation (an atom). There are no mandatory keys
for the environment, but the various environments associate new
keys via assoc when needed.