### PR TITLE
CTYP-285: Core.typed cljc test

### DIFF
--- a/module-check/pom.xml
+++ b/module-check/pom.xml
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.namespace</artifactId>
-      <version>0.2.5</version>
+      <version>0.2.11</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/module-check/src/test/clojure/clojure/core/typed/test/cljc_fail.cljc
+++ b/module-check/src/test/clojure/clojure/core/typed/test/cljc_fail.cljc
@@ -1,0 +1,11 @@
+#?(:clj
+   (ns clojure.core.typed.test.cljc-fail
+     (:require [clojure.core.typed :as t])))
+
+(t/ann fail-func [Number -> Number])
+(defn fail-func
+  "A function designed to generate a type error."
+  [a]
+  (+ a []))
+
+

--- a/module-check/src/test/clojure/clojure/core/typed/test/ctyp_285.clj
+++ b/module-check/src/test/clojure/clojure/core/typed/test/ctyp_285.clj
@@ -1,0 +1,11 @@
+(ns clojure.core.typed.test.ctyp-285
+  (:require [clojure.test :refer :all]
+            [clojure.core.typed :as t]
+            [clojure.core.typed.test.test-utils :refer :all]
+            [clojure.core.typed.test.cljc-fail]))
+
+(deftest fail-on-cljc-type-check-test
+  (is (caught-top-level-errors (constantly true)
+                               (t/check-ns 'clojure.core.typed.test.cljc-fail))))
+
+

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [org.clojure/tools.reader "0.9.2"]
                  [org.clojure/core.contracts "0.0.4" :exclusions [org.clojure/clojure]]
                  [org.clojure/math.combinatorics "0.1.1" :exclusions [org.clojure/clojure]]
-                 [org.clojure/tools.namespace "0.2.5"]
+                 [org.clojure/tools.namespace "0.2.11"]
                  [org.clojure/core.cache "0.6.4"]
                  ]
   ;; for tools.reader 0.9.2


### PR DESCRIPTION
Introduced a test for cljc files which use reader conditional macros.

Created for bug: http://dev.clojure.org/jira/browse/CTYP-285.

Oddly, the bug itself doesn't repro when I execute the test. Maybe it has been fixed somehow.